### PR TITLE
Add lunar calendar support to QS header date

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -7383,6 +7383,13 @@ public final class Settings {
         public static final String QS_SHOW_BATTERY_PERCENT = "qs_show_battery_percent";
 
         /**
+         * Whether to append the lunar calendar date to the Quick Settings header date.
+         * 0 = disabled, 1 = enabled.
+         * @hide
+         */
+        public static final String QS_SHOW_LUNAR_DATE = "qs_show_lunar_date";
+
+        /**
          * Whether to allow one finger quick settings expansion on the side of the statusbar.
          * 0 = 0ff, 1 = right, 2 = left, 3 = both
          * @hide

--- a/packages/SystemUI/res/values-vi/arrays.xml
+++ b/packages/SystemUI/res/values-vi/arrays.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/**
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources>
+    <string-array name="qs_lunar_vietnamese_day_names">
+        <item>Mùng 1</item>
+        <item>Mùng 2</item>
+        <item>Mùng 3</item>
+        <item>Mùng 4</item>
+        <item>Mùng 5</item>
+        <item>Mùng 6</item>
+        <item>Mùng 7</item>
+        <item>Mùng 8</item>
+        <item>Mùng 9</item>
+        <item>Mùng 10</item>
+        <item>Ngày 11</item>
+        <item>Ngày 12</item>
+        <item>Ngày 13</item>
+        <item>Ngày 14</item>
+        <item>Ngày 15</item>
+        <item>Ngày 16</item>
+        <item>Ngày 17</item>
+        <item>Ngày 18</item>
+        <item>Ngày 19</item>
+        <item>Ngày 20</item>
+        <item>Ngày 21</item>
+        <item>Ngày 22</item>
+        <item>Ngày 23</item>
+        <item>Ngày 24</item>
+        <item>Ngày 25</item>
+        <item>Ngày 26</item>
+        <item>Ngày 27</item>
+        <item>Ngày 28</item>
+        <item>Ngày 29</item>
+        <item>Ngày 30</item>
+    </string-array>
+
+    <string-array name="qs_lunar_vietnamese_month_names">
+        <item>Giêng</item>
+        <item>Hai</item>
+        <item>Ba</item>
+        <item>Tư</item>
+        <item>Năm</item>
+        <item>Sáu</item>
+        <item>Bảy</item>
+        <item>Tám</item>
+        <item>Chín</item>
+        <item>Mười</item>
+        <item>Mười Một</item>
+        <item>Chạp</item>
+    </string-array>
+</resources>

--- a/packages/SystemUI/res/values-vi/strings.xml
+++ b/packages/SystemUI/res/values-vi/strings.xml
@@ -393,6 +393,8 @@
     <string name="quick_settings_dark_mode_secondary_label_on_at_bedtime" msgid="2274300599408864897">"Bật vào giờ đi ngủ"</string>
     <string name="quick_settings_dark_mode_secondary_label_until_bedtime_ends" msgid="1790772410777123685">"Đến khi giờ đi ngủ kết thúc"</string>
     <string name="qs_lunar_date_format">"Âm lịch: %1$02d/%2$02d"</string>
+    <string name="qs_lunar_date_leap_suffix">" (Nhuận)"</string>
+    <string name="qs_lunar_date_vietnamese_format">"Âm lịch: %1$s tháng %2$s"</string>
     <string name="qs_lunar_date_combination">"%1$s • %2$s"</string>
     <string name="quick_settings_nfc_label" msgid="1054317416221168085">"NFC"</string>
     <string name="quick_settings_nfc_off" msgid="3465000058515424663">"NFC đã được tắt"</string>

--- a/packages/SystemUI/res/values-vi/strings.xml
+++ b/packages/SystemUI/res/values-vi/strings.xml
@@ -392,6 +392,8 @@
     <string name="quick_settings_dark_mode_secondary_label_until" msgid="2289774641256492437">"Cho đến <xliff:g id="TIME">%s</xliff:g>"</string>
     <string name="quick_settings_dark_mode_secondary_label_on_at_bedtime" msgid="2274300599408864897">"Bật vào giờ đi ngủ"</string>
     <string name="quick_settings_dark_mode_secondary_label_until_bedtime_ends" msgid="1790772410777123685">"Đến khi giờ đi ngủ kết thúc"</string>
+    <string name="qs_lunar_date_format">"Âm lịch: %1$02d/%2$02d"</string>
+    <string name="qs_lunar_date_combination">"%1$s • %2$s"</string>
     <string name="quick_settings_nfc_label" msgid="1054317416221168085">"NFC"</string>
     <string name="quick_settings_nfc_off" msgid="3465000058515424663">"NFC đã được tắt"</string>
     <string name="quick_settings_nfc_on" msgid="1004976611203202230">"NFC đã được bật"</string>

--- a/packages/SystemUI/res/values/arrays.xml
+++ b/packages/SystemUI/res/values/arrays.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/**
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources>
+    <!-- QuickSettings: Fallback day labels used when constructing Vietnamese lunar date strings. -->
+    <string-array name="qs_lunar_vietnamese_day_names">
+        <item>Day 1</item>
+        <item>Day 2</item>
+        <item>Day 3</item>
+        <item>Day 4</item>
+        <item>Day 5</item>
+        <item>Day 6</item>
+        <item>Day 7</item>
+        <item>Day 8</item>
+        <item>Day 9</item>
+        <item>Day 10</item>
+        <item>Day 11</item>
+        <item>Day 12</item>
+        <item>Day 13</item>
+        <item>Day 14</item>
+        <item>Day 15</item>
+        <item>Day 16</item>
+        <item>Day 17</item>
+        <item>Day 18</item>
+        <item>Day 19</item>
+        <item>Day 20</item>
+        <item>Day 21</item>
+        <item>Day 22</item>
+        <item>Day 23</item>
+        <item>Day 24</item>
+        <item>Day 25</item>
+        <item>Day 26</item>
+        <item>Day 27</item>
+        <item>Day 28</item>
+        <item>Day 29</item>
+        <item>Day 30</item>
+    </string-array>
+
+    <!-- QuickSettings: Fallback month labels used when constructing Vietnamese lunar date strings. -->
+    <string-array name="qs_lunar_vietnamese_month_names">
+        <item>First</item>
+        <item>Second</item>
+        <item>Third</item>
+        <item>Fourth</item>
+        <item>Fifth</item>
+        <item>Sixth</item>
+        <item>Seventh</item>
+        <item>Eighth</item>
+        <item>Ninth</item>
+        <item>Tenth</item>
+        <item>Eleventh</item>
+        <item>Twelfth</item>
+    </string-array>
+</resources>

--- a/packages/SystemUI/res/values/config.xml
+++ b/packages/SystemUI/res/values/config.xml
@@ -673,6 +673,9 @@
     <!-- Whether we use large screen shade header which takes only one row compared to QS header -->
     <bool name="config_use_large_screen_shade_header">false</bool>
 
+    <!-- Whether the Quick Settings header should append the lunar calendar date. -->
+    <bool name="config_show_qs_lunar_calendar">false</bool>
+
     <!-- Whether notification header should never show section headers. -->
     <bool name="config_notification_never_show_section_headers">false</bool>
 

--- a/packages/SystemUI/res/values/strings.xml
+++ b/packages/SystemUI/res/values/strings.xml
@@ -960,6 +960,11 @@
     <!-- QuickSettings: Secondary text for when the Dark theme or some other tile will be on until bedtime ends. [CHAR LIMIT=40] -->
     <string name="quick_settings_dark_mode_secondary_label_until_bedtime_ends">Until bedtime ends</string>
 
+    <!-- QuickSettings: Format for the lunar calendar date shown alongside the status date in QS header. -->
+    <string name="qs_lunar_date_format">Lunar: %1$02d/%2$02d</string>
+    <!-- QuickSettings: Combines the standard date and the lunar date in the QS header. -->
+    <string name="qs_lunar_date_combination">%1$s • %2$s</string>
+
     <!-- QuickSettings: NFC tile [CHAR LIMIT=NONE] -->
     <string name="quick_settings_nfc_label">NFC</string>
     <!-- QuickSettings: NFC (off) [CHAR LIMIT=NONE] -->

--- a/packages/SystemUI/res/values/strings.xml
+++ b/packages/SystemUI/res/values/strings.xml
@@ -962,6 +962,10 @@
 
     <!-- QuickSettings: Format for the lunar calendar date shown alongside the status date in QS header. -->
     <string name="qs_lunar_date_format">Lunar: %1$02d/%2$02d</string>
+    <!-- QuickSettings: Suffix appended when the lunar month is a leap month. -->
+    <string name="qs_lunar_date_leap_suffix"> (Leap)</string>
+    <!-- QuickSettings: Format for the Vietnamese localized lunar date. -->
+    <string name="qs_lunar_date_vietnamese_format">Lunar: %1$s month %2$s</string>
     <!-- QuickSettings: Combines the standard date and the lunar date in the QS header. -->
     <string name="qs_lunar_date_combination">%1$s • %2$s</string>
 

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/LunarDateFormatter.kt
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/LunarDateFormatter.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui.statusbar.policy
+
+import android.content.res.Resources
+import android.icu.util.Calendar
+import android.icu.util.ChineseCalendar
+import com.android.systemui.res.R
+
+/**
+ * Helper that formats the lunar calendar date for the QS header.
+ */
+class LunarDateFormatter(private val resources: Resources) {
+
+    /**
+     * Returns the formatted lunar calendar date for [timeInMillis] or `null` when disabled.
+     */
+    fun getFormattedLunarDate(timeInMillis: Long): String? {
+        if (!resources.getBoolean(R.bool.config_show_qs_lunar_calendar)) {
+            return null
+        }
+
+        val calendar = ChineseCalendar()
+        calendar.timeInMillis = timeInMillis
+
+        val day = calendar.get(Calendar.DAY_OF_MONTH)
+        val month = calendar.get(Calendar.MONTH) + 1
+
+        return resources.getString(R.string.qs_lunar_date_format, day, month)
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/LunarDateFormatter.kt
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/LunarDateFormatter.kt
@@ -20,11 +20,15 @@ import android.content.res.Resources
 import android.icu.util.Calendar
 import android.icu.util.ChineseCalendar
 import com.android.systemui.res.R
+import java.util.Locale
 
 /**
  * Helper that formats the lunar calendar date for the QS header.
  */
 class LunarDateFormatter(private val resources: Resources) {
+
+    private val calendar: ChineseCalendar = ChineseCalendar()
+    private val vietnameseLanguage = Locale("vi").language
 
     /**
      * Returns the formatted lunar calendar date for [timeInMillis] or `null` when disabled.
@@ -34,12 +38,54 @@ class LunarDateFormatter(private val resources: Resources) {
             return null
         }
 
-        val calendar = ChineseCalendar()
         calendar.timeInMillis = timeInMillis
 
         val day = calendar.get(Calendar.DAY_OF_MONTH)
         val month = calendar.get(Calendar.MONTH) + 1
+        val isLeapMonth = calendar.get(ChineseCalendar.IS_LEAP_MONTH) == 1
 
-        return resources.getString(R.string.qs_lunar_date_format, day, month)
+        val locale = primaryLocale()
+        return if (locale.language.equals(vietnameseLanguage, ignoreCase = true)) {
+            formatVietnamese(day, month, isLeapMonth)
+        } else {
+            formatDefault(day, month, isLeapMonth)
+        }
+    }
+
+    private fun formatDefault(day: Int, month: Int, isLeapMonth: Boolean): String {
+        val base = resources.getString(R.string.qs_lunar_date_format, day, month)
+        return appendLeapSuffixIfNeeded(base, isLeapMonth)
+    }
+
+    private fun formatVietnamese(day: Int, month: Int, isLeapMonth: Boolean): String {
+        val dayNames = resources.getStringArray(R.array.qs_lunar_vietnamese_day_names)
+        val monthNames = resources.getStringArray(R.array.qs_lunar_vietnamese_month_names)
+        if (day !in 1..dayNames.size || month !in 1..monthNames.size) {
+            return formatDefault(day, month, isLeapMonth)
+        }
+
+        val base = resources.getString(
+            R.string.qs_lunar_date_vietnamese_format,
+            dayNames[day - 1],
+            monthNames[month - 1]
+        )
+        return appendLeapSuffixIfNeeded(base, isLeapMonth)
+    }
+
+    private fun appendLeapSuffixIfNeeded(text: String, isLeapMonth: Boolean): String {
+        if (!isLeapMonth) {
+            return text
+        }
+        val suffix = resources.getString(R.string.qs_lunar_date_leap_suffix)
+        return text + suffix
+    }
+
+    private fun primaryLocale(): Locale {
+        val locales = resources.configuration.locales
+        if (!locales.isEmpty) {
+            return locales[0]
+        }
+        @Suppress("DEPRECATION")
+        return resources.configuration.locale
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/LunarDateFormatter.kt
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/LunarDateFormatter.kt
@@ -29,12 +29,19 @@ class LunarDateFormatter(private val resources: Resources) {
 
     private val calendar: ChineseCalendar = ChineseCalendar()
     private val vietnameseLanguage = Locale("vi").language
+    private val configEnabled = resources.getBoolean(R.bool.config_show_qs_lunar_calendar)
+    private var isEnabled = configEnabled
+
+    /** Sets whether the formatter should output the lunar date in addition to honoring config. */
+    fun setEnabled(enabled: Boolean) {
+        isEnabled = configEnabled && enabled
+    }
 
     /**
      * Returns the formatted lunar calendar date for [timeInMillis] or `null` when disabled.
      */
     fun getFormattedLunarDate(timeInMillis: Long): String? {
-        if (!resources.getBoolean(R.bool.config_show_qs_lunar_calendar)) {
+        if (!isEnabled) {
             return null
         }
 

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/VariableDateViewController.kt
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/VariableDateViewController.kt
@@ -92,6 +92,8 @@ class VariableDateViewController(
     view: VariableDateView
 ) : ViewController<VariableDateView>(view) {
 
+    private val lunarDateFormatter = LunarDateFormatter(view.resources)
+
     private var dateFormat: DateFormat? = null
     private var datePattern = view.longerPattern
         set(value) {
@@ -199,10 +201,49 @@ class VariableDateViewController(
 
         currentTime.time = systemClock.currentTimeMillis()
 
-        val text = getTextForFormat(currentTime, dateFormat!!)
+        val text = getDisplayTextForCurrentPattern()
         if (text != lastText) {
             mView.setText(text)
             lastText = text
+        }
+    }
+
+    private fun getDisplayTextForCurrentPattern(): String {
+        val pattern = datePattern
+        if (pattern.isEmpty()) {
+            return ""
+        }
+
+        val format = dateFormat ?: getFormatFromPattern(pattern)
+        val dateText = getTextForFormat(currentTime, format)
+        if (dateText.isEmpty()) {
+            return dateText
+        }
+
+        val lunarText = lunarDateFormatter.getFormattedLunarDate(currentTime.time)
+        return if (lunarText.isNullOrEmpty()) {
+            dateText
+        } else {
+            mView.resources.getString(R.string.qs_lunar_date_combination, dateText, lunarText)
+        }
+    }
+
+    private fun getCombinedTextForPattern(pattern: String): String {
+        if (pattern.isEmpty()) {
+            return ""
+        }
+
+        val format = getFormatFromPattern(pattern)
+        val dateText = getTextForFormat(currentTime, format)
+        if (dateText.isEmpty()) {
+            return ""
+        }
+
+        val lunarText = lunarDateFormatter.getFormattedLunarDate(currentTime.time)
+        return if (lunarText.isNullOrEmpty()) {
+            dateText
+        } else {
+            mView.resources.getString(R.string.qs_lunar_date_combination, dateText, lunarText)
         }
     }
 
@@ -216,14 +257,15 @@ class VariableDateViewController(
         }
         if (DEBUG) Log.d(TAG, "Width changed. Maybe changing pattern")
         // Start with longer pattern and see what fits
-        var text = getTextForFormat(currentTime, getFormatFromPattern(longerPattern))
+        currentTime.time = systemClock.currentTimeMillis()
+        var text = getCombinedTextForPattern(longerPattern)
         var length = mView.getDesiredWidthForText(text)
         if (length <= availableWidth) {
             changePattern(longerPattern)
             return
         }
 
-        text = getTextForFormat(currentTime, getFormatFromPattern(shorterPattern))
+        text = getCombinedTextForPattern(shorterPattern)
         length = mView.getDesiredWidthForText(text)
         if (length <= availableWidth) {
             changePattern(shorterPattern)

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/VariableDateViewController.kt
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/VariableDateViewController.kt
@@ -20,6 +20,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.database.ContentObserver
 import android.icu.text.DateFormat
 import android.icu.text.DisplayContext
 import android.icu.util.Calendar
@@ -29,6 +30,8 @@ import android.os.UserHandle
 import android.text.TextUtils
 import android.util.Log
 import android.view.View.MeasureSpec
+import android.net.Uri
+import android.provider.Settings
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
@@ -93,6 +96,17 @@ class VariableDateViewController(
 ) : ViewController<VariableDateView>(view) {
 
     private val lunarDateFormatter = LunarDateFormatter(view.resources)
+    private val contentResolver = view.context.contentResolver
+    private val lunarDateSettingUri: Uri =
+        Settings.System.getUriFor(Settings.System.QS_SHOW_LUNAR_DATE)
+    private var lunarDateEnabled = view.resources.getBoolean(R.bool.config_show_qs_lunar_calendar)
+    private val lunarDateObserver =
+        object : ContentObserver(timeTickHandler) {
+            override fun onChange(selfChange: Boolean, uri: Uri?) {
+                updateLunarDateEnabled(triggerRefresh = true)
+            }
+        }
+    private var lunarDateObserverRegistered = false
 
     private var dateFormat: DateFormat? = null
     private var datePattern = view.longerPattern
@@ -135,6 +149,8 @@ class VariableDateViewController(
             // In that case, do not post anything.
             if (handler == null) {
                 shadeLogger.d("VariableDateViewController received intent but handler was null")
+            } else if (Intent.ACTION_USER_SWITCHED == action) {
+                handler.post { updateLunarDateEnabled(triggerRefresh = true) }
             } else if (
                     Intent.ACTION_TIME_TICK == action ||
                     Intent.ACTION_TIME_CHANGED == action ||
@@ -169,16 +185,35 @@ class VariableDateViewController(
         }
     }
 
+    override fun onInit() {
+        super.onInit()
+        updateLunarDateEnabled(triggerRefresh = false)
+    }
+
     override fun onViewAttached() {
         val filter = IntentFilter().apply {
             addAction(Intent.ACTION_TIME_TICK)
             addAction(Intent.ACTION_TIME_CHANGED)
             addAction(Intent.ACTION_TIMEZONE_CHANGED)
             addAction(Intent.ACTION_LOCALE_CHANGED)
+            addAction(Intent.ACTION_USER_SWITCHED)
         }
 
         broadcastDispatcher.registerReceiver(intentReceiver, filter,
                 HandlerExecutor(timeTickHandler), UserHandle.SYSTEM)
+        if (
+            mView.resources.getBoolean(R.bool.config_show_qs_lunar_calendar) &&
+                !lunarDateObserverRegistered
+        ) {
+            contentResolver.registerContentObserver(
+                lunarDateSettingUri,
+                false,
+                lunarDateObserver,
+                UserHandle.USER_ALL
+            )
+            lunarDateObserverRegistered = true
+        }
+        updateLunarDateEnabled(triggerRefresh = false)
         mView.repeatWhenAttached {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 shadeInteractor.qsExpansion.collect(::onQsExpansionFractionChanged)
@@ -190,6 +225,10 @@ class VariableDateViewController(
 
     override fun onViewDetached() {
         dateFormat = null
+        if (lunarDateObserverRegistered) {
+            contentResolver.unregisterContentObserver(lunarDateObserver)
+            lunarDateObserverRegistered = false
+        }
         mView.onAttach(null)
         broadcastDispatcher.unregisterReceiver(intentReceiver)
     }
@@ -208,6 +247,31 @@ class VariableDateViewController(
         }
     }
 
+    private fun updateLunarDateEnabled(triggerRefresh: Boolean) {
+        val configEnabled = mView.resources.getBoolean(R.bool.config_show_qs_lunar_calendar)
+        val defaultValue = if (configEnabled) 1 else 0
+        val enabled =
+            configEnabled &&
+                Settings.System.getIntForUser(
+                    contentResolver,
+                    Settings.System.QS_SHOW_LUNAR_DATE,
+                    defaultValue,
+                    UserHandle.USER_CURRENT
+                ) == 1
+        val changed = enabled != lunarDateEnabled
+        lunarDateEnabled = enabled
+        lunarDateFormatter.setEnabled(enabled)
+
+        if ((changed || triggerRefresh) && isAttachedToWindow) {
+            post {
+                if (lastWidth != Integer.MAX_VALUE) {
+                    maybeChangeFormat(lastWidth)
+                }
+                updateClock()
+            }
+        }
+    }
+
     private fun getDisplayTextForCurrentPattern(): String {
         val pattern = datePattern
         if (pattern.isEmpty()) {
@@ -220,7 +284,12 @@ class VariableDateViewController(
             return dateText
         }
 
-        val lunarText = lunarDateFormatter.getFormattedLunarDate(currentTime.time)
+        val lunarText =
+            if (lunarDateEnabled) {
+                lunarDateFormatter.getFormattedLunarDate(currentTime.time)
+            } else {
+                null
+            }
         return if (lunarText.isNullOrEmpty()) {
             dateText
         } else {
@@ -239,7 +308,12 @@ class VariableDateViewController(
             return ""
         }
 
-        val lunarText = lunarDateFormatter.getFormattedLunarDate(currentTime.time)
+        val lunarText =
+            if (lunarDateEnabled) {
+                lunarDateFormatter.getFormattedLunarDate(currentTime.time)
+            } else {
+                null
+            }
         return if (lunarText.isNullOrEmpty()) {
             dateText
         } else {

--- a/packages/SystemUI/tests/src/com/android/systemui/statusbar/policy/LunarDateFormatterTest.kt
+++ b/packages/SystemUI/tests/src/com/android/systemui/statusbar/policy/LunarDateFormatterTest.kt
@@ -44,6 +44,16 @@ class LunarDateFormatterTest : SysuiTestCase() {
     }
 
     @Test
+    fun getFormattedLunarDate_respectsFormatterToggle() {
+        overrideResource(R.bool.config_show_qs_lunar_calendar, true)
+
+        val formatter = LunarDateFormatter(mContext.resources)
+        formatter.setEnabled(false)
+
+        assertThat(formatter.getFormattedLunarDate(0)).isNull()
+    }
+
+    @Test
     fun getFormattedLunarDate_formatsNumericValuesByDefault() {
         overrideResource(R.bool.config_show_qs_lunar_calendar, true)
         val timeZone = TimeZone.getTimeZone("Asia/Ho_Chi_Minh")

--- a/packages/SystemUI/tests/src/com/android/systemui/statusbar/policy/LunarDateFormatterTest.kt
+++ b/packages/SystemUI/tests/src/com/android/systemui/statusbar/policy/LunarDateFormatterTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui.statusbar.policy
+
+import android.content.res.Configuration
+import android.icu.util.ChineseCalendar
+import android.testing.AndroidTestingRunner
+import androidx.test.filters.SmallTest
+import com.android.systemui.SysuiTestCase
+import com.android.systemui.res.R
+import com.google.common.truth.Truth.assertThat
+import java.util.Calendar
+import java.util.Locale
+import java.util.TimeZone
+import java.util.concurrent.TimeUnit
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidTestingRunner::class)
+@SmallTest
+class LunarDateFormatterTest : SysuiTestCase() {
+
+    @Test
+    fun getFormattedLunarDate_returnsNullWhenDisabled() {
+        overrideResource(R.bool.config_show_qs_lunar_calendar, false)
+
+        val formatter = LunarDateFormatter(mContext.resources)
+
+        assertThat(formatter.getFormattedLunarDate(0)).isNull()
+    }
+
+    @Test
+    fun getFormattedLunarDate_formatsNumericValuesByDefault() {
+        overrideResource(R.bool.config_show_qs_lunar_calendar, true)
+        val timeZone = TimeZone.getTimeZone("Asia/Ho_Chi_Minh")
+        val originalTimeZone = TimeZone.getDefault()
+
+        try {
+            TimeZone.setDefault(timeZone)
+            val timestamp = timestampForLunarNewYear(timeZone)
+
+            val formatter = LunarDateFormatter(mContext.resources)
+            val text = formatter.getFormattedLunarDate(timestamp)
+
+            val expected = mContext.getString(R.string.qs_lunar_date_format, 1, 1)
+            assertThat(text).isEqualTo(expected)
+        } finally {
+            TimeZone.setDefault(originalTimeZone)
+        }
+    }
+
+    @Test
+    fun getFormattedLunarDate_formatsVietnameseTerms() {
+        overrideResource(R.bool.config_show_qs_lunar_calendar, true)
+        val timeZone = TimeZone.getTimeZone("Asia/Ho_Chi_Minh")
+        val originalTimeZone = TimeZone.getDefault()
+
+        try {
+            TimeZone.setDefault(timeZone)
+            val configuration = Configuration(mContext.resources.configuration)
+            configuration.setLocale(Locale("vi", "VN"))
+            val vietnameseContext = mContext.createConfigurationContext(configuration)
+
+            val formatter = LunarDateFormatter(vietnameseContext.resources)
+            val timestamp = timestampForLunarNewYear(timeZone)
+            val text = formatter.getFormattedLunarDate(timestamp)
+
+            val dayName = vietnameseContext.resources
+                .getStringArray(R.array.qs_lunar_vietnamese_day_names)[0]
+            val monthName = vietnameseContext.resources
+                .getStringArray(R.array.qs_lunar_vietnamese_month_names)[0]
+            val expected = vietnameseContext.getString(
+                R.string.qs_lunar_date_vietnamese_format,
+                dayName,
+                monthName
+            )
+            assertThat(text).isEqualTo(expected)
+        } finally {
+            TimeZone.setDefault(originalTimeZone)
+        }
+    }
+
+    @Test
+    fun getFormattedLunarDate_appendsLeapSuffixForLeapMonths() {
+        overrideResource(R.bool.config_show_qs_lunar_calendar, true)
+        val timeZone = TimeZone.getTimeZone("Asia/Ho_Chi_Minh")
+        val originalTimeZone = TimeZone.getDefault()
+
+        try {
+            TimeZone.setDefault(timeZone)
+            val timestamp = findLeapMonthTimestamp(timeZone)
+
+            val formatter = LunarDateFormatter(mContext.resources)
+            val text = formatter.getFormattedLunarDate(timestamp)
+
+            val suffix = mContext.getString(R.string.qs_lunar_date_leap_suffix)
+            assertThat(text).isNotNull()
+            assertThat(text).endsWith(suffix)
+        } finally {
+            TimeZone.setDefault(originalTimeZone)
+        }
+    }
+
+    private fun timestampForLunarNewYear(timeZone: TimeZone): Long {
+        val calendar = Calendar.getInstance(timeZone)
+        calendar.set(2024, Calendar.FEBRUARY, 10, 12, 0, 0)
+        calendar.set(Calendar.MILLISECOND, 0)
+        return calendar.timeInMillis
+    }
+
+    private fun findLeapMonthTimestamp(timeZone: TimeZone): Long {
+        val start = Calendar.getInstance(timeZone).apply {
+            set(2023, Calendar.JANUARY, 1, 12, 0, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
+        val end = Calendar.getInstance(timeZone).apply {
+            set(2024, Calendar.JANUARY, 1, 12, 0, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
+        val chineseCalendar = ChineseCalendar()
+        var time = start.timeInMillis
+        while (time < end.timeInMillis) {
+            chineseCalendar.timeInMillis = time
+            if (chineseCalendar.get(ChineseCalendar.IS_LEAP_MONTH) == 1) {
+                return time
+            }
+            time += TimeUnit.DAYS.toMillis(1)
+        }
+        throw AssertionError("No leap month detected in search window")
+    }
+}

--- a/packages/SystemUI/tests/src/com/android/systemui/statusbar/policy/VariableDateViewControllerTest.kt
+++ b/packages/SystemUI/tests/src/com/android/systemui/statusbar/policy/VariableDateViewControllerTest.kt
@@ -17,6 +17,8 @@
 package com.android.systemui.statusbar.policy
 
 import android.os.Handler
+import android.os.UserHandle
+import android.provider.Settings
 import android.testing.AndroidTestingRunner
 import android.testing.TestableLooper
 import android.view.View
@@ -204,6 +206,12 @@ class VariableDateViewControllerTest : SysuiTestCase() {
     @Test
     fun testLunarDateShownWhenEnabled() {
         overrideResource(R.bool.config_show_qs_lunar_calendar, true)
+        Settings.System.putIntForUser(
+            mContext.contentResolver,
+            Settings.System.QS_SHOW_LUNAR_DATE,
+            1,
+            UserHandle.USER_CURRENT
+        )
 
         controller.onViewDetached()
         clearInvocations(view)
@@ -225,6 +233,101 @@ class VariableDateViewControllerTest : SysuiTestCase() {
         val expectedText =
             mContext.getString(R.string.qs_lunar_date_combination, longText, lunarText)
         assertThat(lastText).isEqualTo(expectedText)
+
+        Settings.System.putIntForUser(
+            mContext.contentResolver,
+            Settings.System.QS_SHOW_LUNAR_DATE,
+            0,
+            UserHandle.USER_CURRENT
+        )
+    }
+
+    @Test
+    fun testLunarDateHiddenWhenSettingDisabled() {
+        overrideResource(R.bool.config_show_qs_lunar_calendar, true)
+        Settings.System.putIntForUser(
+            mContext.contentResolver,
+            Settings.System.QS_SHOW_LUNAR_DATE,
+            0,
+            UserHandle.USER_CURRENT
+        )
+
+        controller.onViewDetached()
+        clearInvocations(view)
+        lastText = null
+
+        controller = VariableDateViewController(
+            systemClock,
+            broadcastDispatcher,
+            shadeInteractor,
+            mock(),
+            testableHandler,
+            view
+        )
+
+        controller.init()
+        testableLooper.processAllMessages()
+
+        assertThat(lastText).isEqualTo(longText)
+    }
+
+    @Test
+    fun testLunarDateUpdatesWhenSettingChanges() {
+        overrideResource(R.bool.config_show_qs_lunar_calendar, true)
+        Settings.System.putIntForUser(
+            mContext.contentResolver,
+            Settings.System.QS_SHOW_LUNAR_DATE,
+            1,
+            UserHandle.USER_CURRENT
+        )
+
+        controller.onViewDetached()
+        clearInvocations(view)
+        lastText = null
+
+        controller = VariableDateViewController(
+            systemClock,
+            broadcastDispatcher,
+            shadeInteractor,
+            mock(),
+            testableHandler,
+            view
+        )
+
+        controller.init()
+        testableLooper.processAllMessages()
+
+        val lunarText = LunarDateFormatter(mContext.resources).getFormattedLunarDate(TIME_STAMP)!!
+        val expectedWithLunar =
+            mContext.getString(R.string.qs_lunar_date_combination, longText, lunarText)
+        assertThat(lastText).isEqualTo(expectedWithLunar)
+
+        Settings.System.putIntForUser(
+            mContext.contentResolver,
+            Settings.System.QS_SHOW_LUNAR_DATE,
+            0,
+            UserHandle.USER_CURRENT
+        )
+        testableLooper.processAllMessages()
+        testableLooper.processAllMessages()
+        assertThat(lastText).isEqualTo(longText)
+
+        Settings.System.putIntForUser(
+            mContext.contentResolver,
+            Settings.System.QS_SHOW_LUNAR_DATE,
+            1,
+            UserHandle.USER_CURRENT
+        )
+        testableLooper.processAllMessages()
+        testableLooper.processAllMessages()
+        assertThat(lastText).isEqualTo(expectedWithLunar)
+
+        Settings.System.putIntForUser(
+            mContext.contentResolver,
+            Settings.System.QS_SHOW_LUNAR_DATE,
+            0,
+            UserHandle.USER_CURRENT
+        )
     }
 
     @Test

--- a/packages/SystemUI/tests/src/com/android/systemui/statusbar/policy/VariableDateViewControllerTest.kt
+++ b/packages/SystemUI/tests/src/com/android/systemui/statusbar/policy/VariableDateViewControllerTest.kt
@@ -23,6 +23,7 @@ import android.view.View
 import androidx.test.filters.SmallTest
 import com.android.systemui.SysuiTestCase
 import com.android.systemui.broadcast.BroadcastDispatcher
+import com.android.systemui.res.R
 import com.android.systemui.shade.domain.interactor.ShadeInteractor
 import com.android.systemui.util.mockito.any
 import com.android.systemui.util.mockito.capture
@@ -37,6 +38,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.Captor
 import org.mockito.Mock
 import org.mockito.Mockito.anyString
+import org.mockito.Mockito.clearInvocations
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
@@ -89,6 +91,7 @@ class VariableDateViewControllerTest : SysuiTestCase() {
         `when`(view.longerPattern).thenReturn(LONG_PATTERN)
         `when`(view.shorterPattern).thenReturn(SHORT_PATTERN)
         `when`(view.handler).thenReturn(testableHandler)
+        `when`(view.resources).thenReturn(mContext.resources)
 
         `when`(view.setText(anyString())).thenAnswer {
             lastText = it.arguments[0] as? String
@@ -196,6 +199,32 @@ class VariableDateViewControllerTest : SysuiTestCase() {
         onMeasureListenerCaptor.value.onMeasureAction(10000, View.MeasureSpec.AT_MOST)
         testableLooper.processAllMessages()
         assertThat(lastText).isEqualTo(shortText)
+    }
+
+    @Test
+    fun testLunarDateShownWhenEnabled() {
+        overrideResource(R.bool.config_show_qs_lunar_calendar, true)
+
+        controller.onViewDetached()
+        clearInvocations(view)
+        lastText = null
+
+        controller = VariableDateViewController(
+            systemClock,
+            broadcastDispatcher,
+            shadeInteractor,
+            mock(),
+            testableHandler,
+            view
+        )
+
+        controller.init()
+        testableLooper.processAllMessages()
+
+        val lunarText = LunarDateFormatter(mContext.resources).getFormattedLunarDate(TIME_STAMP)!!
+        val expectedText =
+            mContext.getString(R.string.qs_lunar_date_combination, longText, lunarText)
+        assertThat(lastText).isEqualTo(expectedText)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add a LunarDateFormatter helper and use it in the quick settings date controller so the lunar date can appear next to the standard date when enabled
- add resources and a configuration flag that control the lunar date text, including a Vietnamese translation
- extend the unit test to verify the lunar date is rendered when the flag is turned on

## Testing
- atest VariableDateViewControllerTest *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cec5213470832fb34228290056b8ae