### PR TITLE
core: Fix attr id shift for 94236802d98747e9ae6ba26ab51db174fc940282

### DIFF
--- a/core/res/res/values/attrs.xml
+++ b/core/res/res/values/attrs.xml
@@ -1136,7 +1136,7 @@
         <attr name="colorAccentPrimary" format="color" />
 
         <!-- Inverse accent color used on Material NEXT buttons. @hide -->
-        <attr name="colorAccentCustom" format="color" />
+        <attr name="zzColorAccentCustom" format="color" />
         
         <!-- Secondary accent color used on Material NEXT buttons. @hide -->
         <attr name="colorAccentSecondary" format="color" />

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -5010,7 +5010,7 @@
   <java-symbol type="bool" name="config_voice_data_sms_auto_fallback" />
 
   <java-symbol type="attr" name="colorAccentPrimary" />
-  <java-symbol type="attr" name="colorAccentCustom" />
+  <java-symbol type="attr" name="zzColorAccentCustom" />
   <java-symbol type="attr" name="colorAccentSecondary" />
   <java-symbol type="attr" name="colorAccentTertiary" />
   <java-symbol type="attr" name="colorAccentPrimaryVariant" />

--- a/core/res/res/values/themes_device_defaults.xml
+++ b/core/res/res/values/themes_device_defaults.xml
@@ -224,7 +224,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_dark</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_dark</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_dark</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_dark</item>
         <item name="colorBackground">@color/system_surface_container_dark</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_dark</item>
@@ -973,7 +973,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -1023,7 +1023,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -1376,7 +1376,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -1410,7 +1410,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -1459,7 +1459,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -1509,7 +1509,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -1561,7 +1561,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -1612,7 +1612,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -1680,7 +1680,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -1722,7 +1722,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -1774,7 +1774,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -1827,7 +1827,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -1881,7 +1881,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="textColorPrimary">@color/system_on_surface_light</item>
         <item name="textColorSecondary">@color/system_on_surface_variant_light</item>
@@ -1915,7 +1915,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="textColorPrimary">@color/system_on_surface_light</item>
         <item name="textColorSecondary">@color/system_on_surface_variant_light</item>
@@ -1948,7 +1948,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -2002,7 +2002,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -2054,7 +2054,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -2105,7 +2105,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -2155,7 +2155,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -2206,7 +2206,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -2254,7 +2254,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -2319,7 +2319,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorEdgeEffect">@color/edge_effect_device_default_light</item>
 
@@ -2359,7 +2359,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorControlNormal">?attr/textColorPrimary</item>
         <item name="alertDialogTheme">@style/Theme.DeviceDefault.Light.Dialog.Alert</item>
@@ -2396,7 +2396,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="alertDialogTheme">@style/Theme.DeviceDefault.Light.Dialog.Alert</item>
 
@@ -2474,7 +2474,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -2533,7 +2533,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -2585,7 +2585,7 @@ easier.
         <item name="colorSurfaceHighlight">@color/system_surface_bright_light</item>
         <item name="colorSurfaceVariant">@color/system_surface_container_high_light</item>
         <item name="colorSurfaceHeader">@color/system_surface_container_highest_light</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
         <item name="colorError">@color/error_color_device_default_light</item>
         <item name="colorBackground">@color/system_surface_container_light</item>
         <item name="colorBackgroundFloating">@color/background_floating_device_default_light</item>
@@ -2700,7 +2700,7 @@ easier.
         <item name="colorAccentPrimary">@color/accent_primary_device_default</item>
         <item name="colorAccentSecondary">@color/system_secondary_dark</item>
         <item name="colorAccentTertiary">@color/system_tertiary_dark</item>
-        <item name="colorAccentCustom">@color/accent_device_default_custom</item>
+        <item name="zzColorAccentCustom">@color/accent_device_default_custom</item>
     </style>
 
     <!-- Theme overlay that replaces colorAccent with the colorAccent from {@link #Theme_DeviceDefault_DayNight}. -->

--- a/packages/SystemUI/src/com/android/systemui/volume/VolumeDialogImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/volume/VolumeDialogImpl.java
@@ -2674,10 +2674,10 @@ public class VolumeDialogImpl implements VolumeDialog, Dumpable,
 
         final ColorStateList bgTint = useActiveColoring
                 ? Utils.getColorAttr(mContext, android.R.attr.colorBackgroundFloating)
-                : Utils.getColorAttr(mContext, com.android.internal.R.attr.colorAccentCustom);
+                : Utils.getColorAttr(mContext, com.android.internal.R.attr.zzColorAccentCustom);
 
         final ColorStateList inverseTextTint = Utils.getColorAttr(
-                mContext, com.android.internal.R.attr.colorAccentCustom);
+                mContext, com.android.internal.R.attr.zzColorAccentCustom);
 
         row.sliderProgressSolid.setTintList(colorTint);
         if (row.sliderProgressIcon != null) {


### PR DESCRIPTION
This would make priv attr id shift +1 and causing some prebuilt apk to crash for using mismatched resource ID. As the build system order these ID by head char, moving it to the end of file would not help, use a "zz" prefix will make sure it's at last and would not affect the original AOSP IDs

For example:
This fixed the crash when you use split screen function on gapps build
Check: Launcher3/quickstep/res/layout/split_instructions_view.xml -> android:textColor="?androidprv:attr/textColorOnAccent" 

NexusLauncher(PixelLauncher) built it with ID 0x01120105(?androidprv:attr/textColorOnAccent) 
On rom with this commit the ID has been +1 from character "c" by "colorAccentCustom", so the ID of textColorOnAccent in system is now 0x01120106, making the prebuilt launcher using 0x01120105 (textAppearance) and crash when parsing a textAppearance to color

All attrs from character "c" have been shifted(a lot), so this might fixed some other problems